### PR TITLE
Remove license-file line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 authors = ["pete.m@expressvpn.com"]
 license = "GPL-2.0"
-license-file = "LICENSE"
 readme = "README.md"
 description = "System bindings for WolfSSL"
 repository = "https://github.com/expressvpn/wolfssl-sys"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove unnecessary `license-file` line from `Cargo.toml`

## Motivation and Context
Presence of both `license` and `license-file` generate a build warning.