### PR TITLE
Add links to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["pete.m@expressvpn.com"]
 license = "GPL-2.0"
@@ -8,6 +8,7 @@ readme = "README.md"
 description = "System bindings for WolfSSL"
 repository = "https://github.com/expressvpn/wolfssl-sys"
 keywords = ["wolfssl", "vpn", "expressvpn", "lightway"]
+links = "wolfssl"
 
 [build-dependencies]
 bindgen = "0.59.2"


### PR DESCRIPTION
## Description
Add `links` to `Cargo.toml` to make Cargo aware that the WolfSSL library is available

## Motivation and Context
Allows other crates to use `wolfsys-sys` as a dependency and re-use the WolfSSL library.