### PR TITLE
Reduce build and test warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["pete.m@expressvpn.com"]
 license = "GPL-2.0"

--- a/build.rs
+++ b/build.rs
@@ -104,6 +104,7 @@ fn main() -> std::io::Result<()> {
         .clang_arg(format!("-I{}/include/", dst_string))
         .parse_callbacks(Box::new(ignored_macros))
         .rustfmt_bindings(true)
+        .blocklist_file("/usr/include/stdlib.h")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+// To work around an issue in bindgen (#1651)
+#![allow(deref_nullptr)]
+
+
 // Pull in the bindings file created during the initial build
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 


### PR DESCRIPTION
## Description

* As described in https://github.com/rust-lang/rust-bindgen/issues/1651 , a number of the tests created by `bindgen` are throwing warnings. There is not yet a resolution path, and the current advice is to ignore those warnings for the time being. This greatly cleans up the test output.
* Block functions in `stdlib.h` from being pulled into the bindings. This also resolves another source of build warnings 
