### PR TITLE
Upgrade wolfssl 5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ keywords = ["wolfssl", "vpn", "expressvpn", "lightway"]
 links = "wolfssl"
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = "0.60.1"
 autotools = "0.2"
 build-target = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["pete.m@expressvpn.com"]
 license = "GPL-2.0"

--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.6
-FROM rust:1.59
+FROM rust:1.62.1
 
 WORKDIR /wolfssl-sys
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Add `wolfssl-sys` to your Cargo manifest:
 
 ```
 [dependencies]
-wolfssl-sys = "0.1.0"
+wolfssl-sys = "0.1.5"
 ```
-To ensure that the crate can be built even offline, the crate includes the source code for WolfSSL (currently version `5.2.0`). WolfSSL uses autotools to build and configure the library so this will need to be install on the build system.
+To ensure that the crate can be built even offline, the crate includes the source code for WolfSSL (currently version `5.4.0`). WolfSSL uses autotools to build and configure the library so this will need to be install on the build system.
 
 ## Building with Earthly
 There is also an `Earthfile` provided so that you can build the crate in [Earthly](https://earthly.dev):

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
-static WOLFSSL_VERSION: &str = "wolfssl-5.3.0-stable";
+static WOLFSSL_VERSION: &str = "wolfssl-5.4.0-stable";
 
 /**
  * Work around for bindgen creating duplicate values.

--- a/build.rs
+++ b/build.rs
@@ -95,6 +95,11 @@ fn build_wolfssl(dest: &str) -> PathBuf {
         conf.enable("armasm", None);
     }
 
+    if build_target::target_arch().unwrap() == build_target::Arch::ARM {
+        // Enable ARM ASM optimisations
+        conf.enable("armasm", None);
+    }
+
     // Build and return the config
     conf.build()
 }


### PR DESCRIPTION
## Summary
* Upgrade to WolfSSL 5.4
* Upgrade bindgen to resolve an issue with the latest `rustc` version (`1.62.1`) #6 
* Enable assembly code on 32bit ARM (ARMv7a)
*
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
Crate builds correctly:

`earthly +build-crate`