### PR TITLE
Support Post Quantum cryptography with liboqs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,29 @@
 [package]
 name = "wolfssl-sys"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["pete.m@expressvpn.com"]
 license = "GPL-2.0"
 readme = "README.md"
 description = "System bindings for WolfSSL"
 repository = "https://github.com/expressvpn/wolfssl-sys"
-keywords = ["wolfssl", "vpn", "expressvpn", "lightway"]
+keywords = ["wolfssl", "vpn", "expressvpn", "lightway", "post-quantum", "cryptography"]
 links = "wolfssl"
 
 [build-dependencies]
 bindgen = "0.60.1"
 autotools = "0.2"
 build-target = "0.4.0"
+
+[dependencies]
+oqs-sys = { version = "0.7.1", default-features = false, features = ["kems", "sigs"], optional = true}
+
+[features]
+default = []
+postquantum = ["dep:oqs-sys"]
+
+
+[package.metadata.cargo-all-features]
+
+# Not an actual feature
+denylist = ["oqs-sys"]

--- a/Earthfile
+++ b/Earthfile
@@ -5,7 +5,7 @@ WORKDIR /wolfssl-sys
 
 build-deps:
     RUN apt-get update -qqy
-    RUN apt-get install -qqy autoconf autotools-dev libtool-bin clang
+    RUN apt-get install -qqy autoconf autotools-dev libtool-bin clang cmake
 
 copy-src:
     FROM +build-deps
@@ -16,12 +16,12 @@ copy-src:
 build-dev:
     FROM +copy-src
     RUN cargo build
-    SAVE ARTIFACT target/debug /release/ AS LOCAL artifacts/debug/
+    SAVE ARTIFACT target/debug /debug AS LOCAL artifacts/debug
 
 build-release:
     FROM +copy-src
     RUN cargo build --release
-    SAVE ARTIFACT target/release /release/ AS LOCAL artifacts/release/
+    SAVE ARTIFACT target/release /release AS LOCAL artifacts/release
 
 run-tests:
     FROM +copy-src

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add `wolfssl-sys` to your Cargo manifest:
 
 ```
 [dependencies]
-wolfssl-sys = "0.1.5"
+wolfssl-sys = "0.1.6"
 ```
 To ensure that the crate can be built even offline, the crate includes the source code for WolfSSL (currently version `5.4.0`). WolfSSL uses autotools to build and configure the library so this will need to be install on the build system.
 
@@ -24,6 +24,16 @@ There is also an `Earthfile` provided so that you can build the crate in [Earthl
 ```
 earthly +build-crate
 ```
+
+## Post Quantum cryptography support
+WolfSSL offers Post Quantum support by leveraging `liboqs`, a library from the [Open Quantum Safe project](https://openquantumsafe.org/). This includes the current hybrid schemes which are the recommended way of experimenting with Post Quantum today. The feature is not enabled by default as it requires building and linking against `liboqs` which would increase the library size and increase compile time. It can be enabled by enabling the `postquantum` feature:
+
+``` toml
+[dependencies]
+wolfssl-sys = { version = "0.1.6" features = ["postquantum"] }
+```
+
+This will automatically build `liboqs` from the `oqs-sys` crate and link WolfSSL against it, making definitions such as `WOLFSSL_P521_KYBER_LEVEL5` available.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ wolfssl-sys = { version = "0.1.6" features = ["postquantum"] }
 
 This will automatically build `liboqs` from the `oqs-sys` crate and link WolfSSL against it, making definitions such as `WOLFSSL_P521_KYBER_LEVEL5` available.
 
+## Contributors
+A number of people have taken the time to contribute towards this crate. From opening valuable issues, to contributing a line or two of code, we would like to give credit for their help here:
+
+
 ## TODO
 
 * Resolve the warnings in the auto generated tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,4 +23,28 @@ mod tests {
             assert_eq!(res, WOLFSSL_SUCCESS);
         }
     }
+
+    #[test]
+    #[cfg(feature = "postquantum")]
+    fn test_post_quantum_available() {
+        unsafe {
+            // Init WolfSSL
+            let res = wolfSSL_Init();
+
+            // Set up client method
+            let method = wolfTLSv1_3_client_method();
+
+            // Create context
+            let context = wolfSSL_CTX_new(method);
+
+            // Create new SSL stream
+            let ssl = wolfSSL_new(context);
+
+            // Enable Kyber
+            let res = wolfSSL_UseKeyShare(ssl, WOLFSSL_P521_KYBER_LEVEL5.try_into().unwrap());
+
+            // Check that Kyber was enabled
+            assert_eq!(res, WOLFSSL_SUCCESS);
+        }
+    }
 }


### PR DESCRIPTION
This adds a new feature to the crated called `postquantum`. Enabling the feature will compile in `liboqs` (see `README.md`) which will give WolfSSL access to its various schemes.

## Motivation and Context
* Easiest way to test PQ with WolfSSL
* Will make it easy to test with Lightway

