### PR TITLE
Update WolfSSL to 5.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 authors = ["pete.m@expressvpn.com"]
 license = "GPL-2.0"

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Add `wolfssl-sys` to your Cargo manifest:
 
 ```
 [dependencies]
-wolfssl-sys = "0.1.12"
+wolfssl-sys = "0.1.13"
 ```
-To ensure that the crate can be built even offline, the crate includes the source code for WolfSSL (currently version `5.5.2`). WolfSSL uses autotools to build and configure the library so this will need to be installed on the build system.
+To ensure that the crate can be built even offline, the crate includes the source code for WolfSSL (currently version `5.5.3`). WolfSSL uses autotools to build and configure the library so this will need to be installed on the build system.
 
 Note: This crate includes a patch from the WolfSSL master branch to improve reporting with Post Quantum curves. It has no other effect and as it is already merged into master, will be removed when WolfSSL cuts a new release.
 
@@ -32,7 +32,7 @@ WolfSSL offers Post Quantum support by leveraging `liboqs`, a library from the [
 
 ``` toml
 [dependencies]
-wolfssl-sys = { version = "0.1.12" features = ["postquantum"] }
+wolfssl-sys = { version = "0.1.13" features = ["postquantum"] }
 ```
 
 This will automatically build `liboqs` from the `oqs-sys` crate and link WolfSSL against it, making definitions such as `WOLFSSL_P521_KYBER_LEVEL5` available.

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
-static WOLFSSL_VERSION: &str = "wolfssl-5.5.2-stable";
+static WOLFSSL_VERSION: &str = "wolfssl-5.5.3-stable";
 
 /**
  * Work around for bindgen creating duplicate values.


### PR DESCRIPTION
Update WolfSSL to version 5.5.3

## How Has This Been Tested?
`cargo test-all-features` passes.
