### PR TITLE
fix: earthfile: Also copy the `examples` dir

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -12,6 +12,7 @@ copy-src:
     COPY Cargo.toml wrapper.h build.rs ./
     COPY --dir src ./
     COPY --dir vendor ./
+    COPY --dir examples ./
 
 build-dev:
     FROM +copy-src


### PR DESCRIPTION
Otherwise `earthly +build_dev` will complain with:
```
error: failed to parse manifest at `/wolfssl-sys/Cargo.toml`

Caused by:
  can't find `connect_pq` example at `examples/connect_pq.rs` or `examples/connect_pq/main.rs`...
```