### PR TITLE
Add basic CI actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches: [main]
+  pull_request: null # target every PR
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: earthly/actions/setup-earthly@v1
+        with:
+          version: v0.6.30
+      - uses: actions/checkout@v2
+      - name: Run Tests
+        run: earthly --ci +run-tests
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: earthly/actions/setup-earthly@v1
+        with:
+          version: v0.6.30
+      - uses: actions/checkout@v2
+      - name: Build crate
+        run: earthly --ci +build-release


### PR DESCRIPTION
We don't turn on the knobs and fail on warnings just yet, since there are existing warnings generated by `bindgen` complaining about bindings to certain variadic functions like `printf`. This is to ensure that we don't accidentally merge in a failing build.
