### PR TITLE
earthfile: Install `rustfmt`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -6,6 +6,7 @@ WORKDIR /wolfssl-sys
 build-deps:
     RUN apt-get update -qqy
     RUN apt-get install -qqy autoconf autotools-dev libtool-bin clang cmake
+    RUN rustup component add rustfmt
 
 copy-src:
     FROM +build-deps


### PR DESCRIPTION
This formats `bindings.rs`, which previously would ignore the `.rustfmt_bindings(true)` configuration
