### PR TITLE
github: Fix codeowner hierarchy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Global rule:
-*                         @expressvpn-pete-m
-*                         @expressvpn-pang-t
+*                         @expressvpn-pete-m @expressvpn-pang-t


### PR DESCRIPTION
The previous expression would mean that while `pete-m` could approve my stuff the reverse is not true
