### PR TITLE
Upgrade to WolfSSL 5.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wolfssl-sys"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "autotools",
  "bindgen 0.64.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 authors = ["pete.m@expressvpn.com"]
 license = "GPL-2.0"

--- a/Earthfile
+++ b/Earthfile
@@ -41,4 +41,5 @@ build-crate:
 lint:
     FROM +copy-src
     RUN rustup component add clippy
+    RUN apt-get install -qqy bsdextrautils
     RUN cargo clippy --all-features --all-targets -- -D warnings

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Add `wolfssl-sys` to your Cargo manifest:
 
 ```
 [dependencies]
-wolfssl-sys = "0.1.14"
+wolfssl-sys = "0.1.15"
 ```
-To ensure that the crate can be built even offline, the crate includes the source code for WolfSSL (currently version `5.5.4`). WolfSSL uses autotools and automake to build and configure the library so this will need to be installed on the build system.
+To ensure that the crate can be built even offline, the crate includes the source code for WolfSSL (currently version `5.6.0`). WolfSSL uses autotools and automake to build and configure the library so this will need to be installed on the build system.
 
 Note: This crate includes a patch from the WolfSSL master branch to improve reporting with Post Quantum curves. It has no other effect and as it is already merged into master, will be removed when WolfSSL cuts a new release.
 
@@ -32,7 +32,7 @@ WolfSSL offers Post Quantum support by leveraging `liboqs`, a library from the [
 
 ``` toml
 [dependencies]
-wolfssl-sys = { version = "0.1.14" features = ["postquantum"] }
+wolfssl-sys = { version = "0.1.15" features = ["postquantum"] }
 ```
 
 This will automatically build `liboqs` from the `oqs-sys` crate and link WolfSSL against it, making definitions such as `WOLFSSL_P521_KYBER_LEVEL5` available.

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
-static WOLFSSL_VERSION: &str = "wolfssl-5.5.4-stable";
+static WOLFSSL_VERSION: &str = "wolfssl-5.6.0-stable";
 
 /**
  * Work around for bindgen creating duplicate values.


### PR DESCRIPTION
Upgrade to the latest release of WolfSSL (`5.6.0`)

## How Has This Been Tested?
This has been tested with:

```
cargo test-all-features
```
