### PR TITLE
Update `oqs-sys` tracking commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 [[package]]
 name = "oqs-sys"
 version = "0.7.2"
-source = "git+https://github.com/open-quantum-safe/liboqs-rust#f7bd5038018f2d69c55b642fcc373ae445ac378a"
+source = "git+https://github.com/open-quantum-safe/liboqs-rust?rev=f7bd5038018f2d69c55b642fcc373ae445ac378a#f7bd5038018f2d69c55b642fcc373ae445ac378a"
 dependencies = [
  "bindgen",
  "build-deps",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 [[package]]
 name = "oqs-sys"
 version = "0.7.2"
-source = "git+https://github.com/open-quantum-safe/liboqs-rust?rev=f7bd5038018f2d69c55b642fcc373ae445ac378a#f7bd5038018f2d69c55b642fcc373ae445ac378a"
+source = "git+https://github.com/open-quantum-safe/liboqs-rust?rev=10c540350d86fa71110b325f4883f421cb326970#10c540350d86fa71110b325f4883f421cb326970"
 dependencies = [
  "bindgen",
  "build-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ build-target = "0.4.0"
 
 [dependencies.oqs-sys]
 git = "https://github.com/open-quantum-safe/liboqs-rust"
-rev = "f7bd5038018f2d69c55b642fcc373ae445ac378a"
+rev = "10c540350d86fa71110b325f4883f421cb326970"
 default-features = false
 features = ["kems", "sigs"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ build-target = "0.4.0"
 
 [dependencies.oqs-sys]
 git = "https://github.com/open-quantum-safe/liboqs-rust"
-commit = "f7bd5038018f2d69c55b642fcc373ae445ac378a"
+rev = "f7bd5038018f2d69c55b642fcc373ae445ac378a"
 default-features = false
 features = ["kems", "sigs"]
 optional = true


### PR DESCRIPTION
Update `oqs-sys` with [these commits](https://github.com/open-quantum-safe/liboqs-rust/compare/f7bd5038018f2d69c55b642fcc373ae445ac378a...10c540350d86fa71110b325f4883f421cb326970).