### PR TITLE
Add github meta job which depends on all jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,13 @@ on:
     branches: [main]
   pull_request: null # target every PR
 jobs:
+  ci:
+    needs: [test, build, fmt, lint, cargo-deny]
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          echo "Build success"
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a new github meta job which depends on all other jobs

## Motivation and Context
Currently we need to specify all the required jobs in CI workflow as required checks in branch protection rule.
Having a meta job which depends on all other jobs reduce this dependency

And we can use this meta job as required checks in branch protection rules.

## How Has This Been Tested?

Tested CI with the current PR:

_Success run:_
https://github.com/expressvpn/wolfssl-sys/actions/runs/6168391857

_Failure run:_
https://github.com/expressvpn/wolfssl-sys/actions/runs/6168435033

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`