### PR TITLE
GHA: Automatic update of Rust toolchain version

### DIFF
--- a/.github/workflows/nightly-rust-update-check.yaml
+++ b/.github/workflows/nightly-rust-update-check.yaml
@@ -1,0 +1,42 @@
+name: Nightly Rust release checks
+on:
+  schedule:
+    - cron:  '50 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-for-updated-rust:
+    runs-on: ubuntu-latest
+    environment: expressvpn_iat_automation_githubiatuser_gpg_key
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Import GPG Key
+      uses: crazy-max/ghaction-import-gpg@v5
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+
+    - name: Check for Rust update
+      id: check-version
+      run: |
+        rustup install stable
+        stable=$(rustup run stable rustc -V | sed -E -e 's/^rustc ([0-9\.]+) \(.*\)$/\1/g')
+        echo "Latest stable rust is ${stable}"
+
+        echo rust="$stable" >> "$GITHUB_OUTPUT"
+
+    - name: Update Rust version in Earthfile
+      run: sed -i -E 's/^(\s*FROM rust):(:?[0-9\.]+)$/\1:${{ steps.check-version.outputs.rust }}/g' Earthfile
+
+    - uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+        delete-branch: true
+        committer: ExpressVPN Automation Bot <143369453+expressvpn-iat-bot@users.noreply.github.com>
+        author: ExpressVPN Automation Bot <143369453+expressvpn-iat-bot@users.noreply.github.com>
+        commit-message: "[auto] Update Rust toolchain to ${{ steps.check-version.outputs.rust }}"
+        branch: gha/rust-toolchain-update
+        title: "[auto] Update Rust toolchain to ${{ steps.check-version.outputs.rust }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A nightly GHA which checks for a new version of Rust and raises a PR updating `Earthfile` if needed.

Note that Rust releases roughly every 6 weeks, with occasional point releases, so ~41/42 times the GHA will be a NOP

## Motivation and Context

Ensures that we keep up to date with latest Rust versions.

## How Has This Been Tested?

This requires `environment: expressvpn_iat_automation_githubiatuser_gpg_key` which is only available from the `main` branch.

The bits around `crazy-max/ghaction-import-gpg@v5` and `peter-evans/create-pull-request@v5` are, apart from the commit message, the same as the existing `.github/workflows/weekly-cargo-update.yaml` action so :crossed_fingers: should be ok.

The "Check for Rust update" bit I've used on other projects.

The "Update Rust version in Earthfile" I've tested locally with dummy values.

Note that [Rust 1.72.1 is scheduled for 19 September](https://internals.rust-lang.org/t/rust-1-72-1-pre-release-testing/19566) so we'll be able to try this for real then.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All active GitHub checks are passing  
- [ ] The correct base branch is being used, if not `main`